### PR TITLE
remove references to deprecated ::Parts and ::UploadIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
-## Unreleased
+## 2.0.0
+  * Drop support for 'multipart-post' < 2.2.0
+  * Change references to UploadIO and Parts according to class reorganization in 'multipart-post' 2.2.0 (PR [#89](https://github.com/socketry/multipart-post/pull/89))
 
 *   Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
 ## Unreleased
+  * Drop support for 'multipart-post' < 2.0.0. This is not a breaking change as the code didn't work with 1.x.
+  * Change references to UploadIO and Parts according to class reorganization in 'multipart-post' 2.2.0 (PR [#89](https://github.com/socketry/multipart-post/pull/89))
+  * Introduce a backwards compatible safeguard so the gem still works with previous 'multipart-post' 2.x releases.
+
 
 *   Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 # Changelog
 
+## Unreleased
+
 *   Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
 # Changelog
 
-## 2.0.0
-  * Drop support for 'multipart-post' < 2.2.0
-  * Change references to UploadIO and Parts according to class reorganization in 'multipart-post' 2.2.0 (PR [#89](https://github.com/socketry/multipart-post/pull/89))
-
 *   Initial release.

--- a/faraday-multipart.gemspec
+++ b/faraday-multipart.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4', '< 4'
 
-  spec.add_dependency 'multipart-post', '>= 2.0.0', '< 3'
+  spec.add_dependency 'multipart-post', '~> 2'
 end

--- a/faraday-multipart.gemspec
+++ b/faraday-multipart.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4', '< 4'
 
-  spec.add_dependency 'multipart-post', '>= 1.2', '< 3'
+  spec.add_dependency 'multipart-post', '>= 2.2.0', '~> 2'
 end

--- a/faraday-multipart.gemspec
+++ b/faraday-multipart.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4', '< 4'
 
-  spec.add_dependency 'multipart-post', '>= 2.2.0', '~> 2'
+  spec.add_dependency 'multipart-post', '>= 2.0.0', '< 3'
 end

--- a/lib/faraday/multipart.rb
+++ b/lib/faraday/multipart.rb
@@ -16,5 +16,5 @@ module Faraday
   ParamPart = Multipart::ParamPart
   Parts = Multipart::Parts
   CompositeReadIO = Multipart::CompositeReadIO
-  UploadIO = ::UploadIO
+  UploadIO = ::Multipart::Post::UploadIO
 end

--- a/lib/faraday/multipart.rb
+++ b/lib/faraday/multipart.rb
@@ -5,6 +5,8 @@ require_relative 'multipart/param_part'
 require_relative 'multipart/middleware'
 require_relative 'multipart/version'
 
+require 'multipart/post/version'
+
 module Faraday
   # Main Faraday::Multipart module.
   module Multipart
@@ -16,5 +18,11 @@ module Faraday
   ParamPart = Multipart::ParamPart
   Parts = Multipart::Parts
   CompositeReadIO = Multipart::CompositeReadIO
-  UploadIO = ::Multipart::Post::UploadIO
+  # multipart-post v2.2.0 introduces a new class hierarchy for classes like Parts and UploadIO
+  # For backwards compatibility, detect the gem version and use the right class
+  UploadIO = if ::Gem::Requirement.new('>= 2.2.0').satisfied_by?(::Gem::Version.new(::Multipart::Post::VERSION))
+               ::Multipart::Post::UploadIO
+             else
+               ::UploadIO
+             end
 end

--- a/lib/faraday/multipart.rb
+++ b/lib/faraday/multipart.rb
@@ -20,7 +20,7 @@ module Faraday
   CompositeReadIO = Multipart::CompositeReadIO
   # multipart-post v2.2.0 introduces a new class hierarchy for classes like Parts and UploadIO
   # For backwards compatibility, detect the gem version and use the right class
-  UploadIO = if ::Gem::Requirement.new('>= 2.2.0').satisfied_by?(::Gem::Version.new(::Multipart::Post::VERSION))
+  UploadIO = if ::Gem::Requirement.new('>= 2.2.0').satisfied_by?(Multipart::MULTIPART_POST_VERSION)
                ::Multipart::Post::UploadIO
              else
                ::UploadIO

--- a/lib/faraday/multipart.rb
+++ b/lib/faraday/multipart.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
+require_relative 'multipart/version'
 require_relative 'multipart/file_part'
 require_relative 'multipart/param_part'
 require_relative 'multipart/middleware'
-require_relative 'multipart/version'
 
 module Faraday
   # Main Faraday::Multipart module.
@@ -18,7 +18,7 @@ module Faraday
   CompositeReadIO = Multipart::CompositeReadIO
   # multipart-post v2.2.0 introduces a new class hierarchy for classes like Parts and UploadIO
   # For backwards compatibility, detect the gem version and use the right class
-  UploadIO = if ::Gem::Requirement.new('>= 2.2.0').satisfied_by?(Multipart::MULTIPART_POST_VERSION)
+  UploadIO = if ::Gem::Requirement.new('>= 2.2.0').satisfied_by?(Multipart.multipart_post_version)
                ::Multipart::Post::UploadIO
              else
                ::UploadIO

--- a/lib/faraday/multipart.rb
+++ b/lib/faraday/multipart.rb
@@ -10,6 +10,8 @@ require 'multipart/post/version'
 module Faraday
   # Main Faraday::Multipart module.
   module Multipart
+    MULTIPART_POST_VERSION = ::Gem::Version.new(::Multipart::Post::VERSION)
+
     Faraday::Request.register_middleware(multipart: Faraday::Multipart::Middleware)
   end
 

--- a/lib/faraday/multipart.rb
+++ b/lib/faraday/multipart.rb
@@ -5,13 +5,9 @@ require_relative 'multipart/param_part'
 require_relative 'multipart/middleware'
 require_relative 'multipart/version'
 
-require 'multipart/post/version'
-
 module Faraday
   # Main Faraday::Multipart module.
   module Multipart
-    MULTIPART_POST_VERSION = ::Gem::Version.new(::Multipart::Post::VERSION)
-
     Faraday::Request.register_middleware(multipart: Faraday::Multipart::Middleware)
   end
 

--- a/lib/faraday/multipart/file_part.rb
+++ b/lib/faraday/multipart/file_part.rb
@@ -3,8 +3,12 @@
 require 'stringio'
 
 require 'multipart/post'
+require 'multipart/post/version'
 
 module Faraday
+  # Rubocop doesn't seem to understand that this is an extension to the
+  # Multipart module, so let's add a nodoc
+  # #:nodoc:
   module Multipart
     # Multipart value used to POST a binary data from a file or
     #
@@ -49,9 +53,13 @@ module Faraday
     # The open IO object for the uploaded file.
     #
     # @return [IO]
-    FilePart = ::Multipart::Post::UploadIO
-
-    Parts = ::Multipart::Post::Parts
+    if ::Gem::Requirement.new('>= 2.2.0').satisfied_by?(MULTIPART_POST_VERSION)
+      FilePart = ::Multipart::Post::UploadIO
+      Parts = ::Multipart::Post::Parts
+    else
+      FilePart = ::UploadIO
+      Parts = ::Parts
+    end
 
     # Similar to, but not compatible with CompositeReadIO provided by the
     # multipart-post gem.

--- a/lib/faraday/multipart/file_part.rb
+++ b/lib/faraday/multipart/file_part.rb
@@ -2,9 +2,6 @@
 
 require 'stringio'
 
-require 'multipart/post'
-require 'multipart/post/version'
-
 module Faraday
   # Rubocop doesn't seem to understand that this is an extension to the
   # Multipart module, so let's add a nodoc
@@ -54,9 +51,12 @@ module Faraday
     #
     # @return [IO]
     if ::Gem::Requirement.new('>= 2.2.0').satisfied_by?(MULTIPART_POST_VERSION)
+      require 'multipart/post'
       FilePart = ::Multipart::Post::UploadIO
       Parts = ::Multipart::Post::Parts
     else
+      require 'composite_io'
+      require 'parts'
       FilePart = ::UploadIO
       Parts = ::Parts
     end

--- a/lib/faraday/multipart/file_part.rb
+++ b/lib/faraday/multipart/file_part.rb
@@ -2,9 +2,7 @@
 
 require 'stringio'
 
-# multipart-post gem
-require 'composite_io'
-require 'parts'
+require 'multipart/post'
 
 module Faraday
   module Multipart
@@ -51,9 +49,9 @@ module Faraday
     # The open IO object for the uploaded file.
     #
     # @return [IO]
-    FilePart = ::UploadIO
+    FilePart = ::Multipart::Post::UploadIO
 
-    Parts = ::Parts
+    Parts = ::Multipart::Post::Parts
 
     # Similar to, but not compatible with CompositeReadIO provided by the
     # multipart-post gem.

--- a/lib/faraday/multipart/file_part.rb
+++ b/lib/faraday/multipart/file_part.rb
@@ -50,7 +50,7 @@ module Faraday
     # The open IO object for the uploaded file.
     #
     # @return [IO]
-    if ::Gem::Requirement.new('>= 2.2.0').satisfied_by?(MULTIPART_POST_VERSION)
+    if ::Gem::Requirement.new('>= 2.2.0').satisfied_by?(multipart_post_version)
       require 'multipart/post'
       FilePart = ::Multipart::Post::UploadIO
       Parts = ::Multipart::Post::Parts

--- a/lib/faraday/multipart/version.rb
+++ b/lib/faraday/multipart/version.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 module Faraday
+  # #:nodoc:
   module Multipart
     VERSION = '1.0.3'
-    begin
+
+    def self.multipart_post_version
       require 'multipart/post/version'
-      MULTIPART_POST_VERSION = ::Gem::Version.new(::Multipart::Post::VERSION)
+      ::Gem::Version.new(::Multipart::Post::VERSION)
     rescue LoadError
       require 'multipart_post'
-      MULTIPART_POST_VERSION = ::Gem::Version.new(::MultipartPost::VERSION)
+      ::Gem::Version.new(::MultipartPost::VERSION)
     end
   end
 end

--- a/lib/faraday/multipart/version.rb
+++ b/lib/faraday/multipart/version.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-require 'multipart/post/version'
-
 module Faraday
   module Multipart
     VERSION = '1.0.3'
-    MULTIPART_POST_VERSION = ::Gem::Version.new(::Multipart::Post::VERSION)
   end
 end

--- a/lib/faraday/multipart/version.rb
+++ b/lib/faraday/multipart/version.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+require 'multipart/post/version'
+
 module Faraday
   module Multipart
     VERSION = '1.0.3'
+    MULTIPART_POST_VERSION = ::Gem::Version.new(::Multipart::Post::VERSION)
   end
 end

--- a/lib/faraday/multipart/version.rb
+++ b/lib/faraday/multipart/version.rb
@@ -2,6 +2,6 @@
 
 module Faraday
   module Multipart
-    VERSION = '1.0.3'
+    VERSION = '2.0.0'
   end
 end

--- a/lib/faraday/multipart/version.rb
+++ b/lib/faraday/multipart/version.rb
@@ -2,6 +2,6 @@
 
 module Faraday
   module Multipart
-    VERSION = '2.0.0'
+    VERSION = '1.0.3'
   end
 end

--- a/lib/faraday/multipart/version.rb
+++ b/lib/faraday/multipart/version.rb
@@ -3,5 +3,12 @@
 module Faraday
   module Multipart
     VERSION = '1.0.3'
+    begin
+      require 'multipart/post/version'
+      MULTIPART_POST_VERSION = ::Gem::Version.new(::Multipart::Post::VERSION)
+    rescue LoadError
+      require 'multipart_post'
+      MULTIPART_POST_VERSION = ::Gem::Version.new(::MultipartPost::VERSION)
+    end
   end
 end


### PR DESCRIPTION
Here's my attempt at bringing faraday-multipart up to par with multipart-post recent class reorganization changes.
This PR:
* changes class references according to https://github.com/socketry/multipart-post/pull/89
  * `::UploadIO` to `::Multipart::Post::UploadIO` 
  * `::Parts` to `::Multipart::Post::Parts`
* replaces fine grained requires with `require 'multipart/post'` as per [recommendation](https://github.com/socketry/multipart-post/pull/89/files#diff-efc00903f0c4e128baf8ec1f03b3bfc3c5f7e85e3df4a2c624dcb9f092cac591R1)
* bumps this gem to the next major version as it now has a lower bound requirement of 'multipart-post', '>= 2.2.0' (where previously it was `>= 1.2`. This change can be made to a minor or patch version bump instead, up to the maintainer.

fixes #5 