### PR TITLE
Add The Ability To Specify A Different Content Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ conn = Faraday.new(...) do |f|
 end
 ```
 
+If you need to [specify a different content type for the multipart
+request](https://www.iana.org/assignments/media-types/media-types.xhtml#multipart),
+you can do so by providing the `content_type` option but it must start with
+`multipart/`
+otherwise it will default to `multipart/form-data`:
+
+```ruby
+conn = Faraday.new(...) do |f|
+  f.request :multipart, content_type: 'multipart/mixed'
+  # ...
+end
+```
 
 Payload can be a mix of POST data and multipart values.
 

--- a/spec/faraday/multipart/middleware_spec.rb
+++ b/spec/faraday/multipart/middleware_spec.rb
@@ -315,4 +315,49 @@ RSpec.describe Faraday::Multipart::Middleware do
       expect(response.body).not_to include('name="b[]"')
     end
   end
+
+  context 'when passing content_type option' do
+    let(:payload) do
+      {
+        xml: Faraday::Multipart::ParamPart.new('<xml><value /></xml>', 'text/xml'),
+        io: Faraday::Multipart::FilePart.new(StringIO.new('io-content'), 'application/octet-stream')
+      }
+    end
+
+    context 'when a multipart mime type is provided' do
+      let(:options) { { content_type: 'multipart/mixed' } }
+
+      it_behaves_like 'a multipart request'
+
+      it 'uses the provided mime type' do
+        response = conn.post('/echo', payload)
+
+        expect(response.headers['Content-Type']).to start_with('multipart/mixed')
+      end
+    end
+
+    context 'when a non-multipart mime type is provided' do
+      let(:options) { { content_type: 'application/json' } }
+
+      it_behaves_like 'a multipart request'
+
+      it 'uses the default mime type' do
+        response = conn.post('/echo', payload)
+
+        expect(response.headers['Content-Type']).to start_with('multipart/form-data')
+      end
+    end
+
+    context 'when no multipart mime type is provided' do
+      let(:options) { {} }
+
+      it_behaves_like 'a multipart request'
+
+      it 'uses the default mime type' do
+        response = conn.post('/echo', payload)
+
+        expect(response.headers['Content-Type']).to start_with('multipart/form-data')
+      end
+    end
+  end
 end


### PR DESCRIPTION
When trying to use faraday-multipart for Publishing Flows Tableau API's I was giving an error because Tableau's APIs multipart APIs only allow a `Content-Type: multipart/mixed`.

As noted in the comment below by @olleolleolle [there are many different accepted mime types for multipart requests](https://www.iana.org/assignments/media-types/media-types.xhtml#multipart) and this change provides the option to specify a different one.

The new option for this middleware provided in this PR:
```ruby
client = Faraday.new(url:, headers:) do |builder|
  builder.request :multipart, content_type: 'multipart/mixed'
end
```

If a multipart mime type is not specified the middleware will default to multipart/form-data.

This change also changes the structure of the middleware a bit.

It changes the parent from UrlEncoded to inherit from Middleware directly instead. This is because we were overriding most of the UrlEncoded methods anyway so bringing last remaining methods over and removing that link in the dependency chain seemed to make sense.

Another structural code change was to move the methods that didn't need to be public under the private keyword. The intent of this was to help future developers know what they can change without worrying about breaking any external dependencies.