### PR TITLE
Prepare Trusted Publisher

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,9 @@ jobs:
   build:
     name: Publish to Rubygems
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -18,6 +20,4 @@ jobs:
           ruby-version: 2.7
 
       - name: Publish to RubyGems
-        uses: dawidd6/action-publish-gem@v1
-        with:
-          api_key: ${{secrets.RUBYGEMS_AUTH_TOKEN}}
+        uses: rubygems/release-gem@v1


### PR DESCRIPTION
This PR makes the changes in the Workflow which makes use Trusted Publisher.  https://guides.rubygems.org/trusted-publishing/adding-a-publisher/

> [!NOTE]
> Merge this when the relevant RubyGems.org changes are in!