### PR TITLE
Relax `required_ruby_version` to support Ruby 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: rm .ruby-version
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -26,9 +26,9 @@ jobs:
       matrix:
         ## Due to https://github.com/actions/runner/issues/849,
         ## we have to use quotes for '3.0'
-        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         ## Due to https://github.com/actions/runner/issues/849,
         ## we have to use quotes for '3.0'
-        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'bundler', '~> 2.0'
   gem 'faraday', '>= 1.0'
   gem 'multipart-parser'
   gem 'rake', '~> 13.0'

--- a/faraday-multipart.gemspec
+++ b/faraday-multipart.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'README.md', 'LICENSE.md', 'CHANGELOG.md']
 
-  spec.required_ruby_version = '>= 2.4', '< 4'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_dependency 'multipart-post', '~> 2.0'
 end


### PR DESCRIPTION
This Pull Request relaxed the `required_ruby_version` to allow Ruby 4.0.

The current gemspec specifies an upper bound of "< 4", which prevents `gem install faraday-multipart` from working on Ruby 4.0, scheduled for release on December 25. By removing this upper bound, the gem will continue to work on Ruby 4.0 and future Ruby versions.

- Ruby 4.0.0 preview3 Released
  - https://www.ruby-lang.org/en/news/2025/12/18/ruby-4-0-0-preview3-released/

### Additional Information
#### Bundler version for development / test environments
This Pull Request removes the development dependency on the bundler gem.
In Ruby 4.0, Bundler is provided as a default gem with version 4.0 or later.

https://github.com/lostisland/faraday-multipart/blob/b02f76175d11a126164e632db3ca6c0861d445d5/Gemfile#L8

#### Update CI Matrix
This Pull Request also:
- adds Ruby 3.2 - 4.0 to the CI matrix
- bumps actions/checkout from v4 to v6